### PR TITLE
refactor: separate Hint and IndexHint

### DIFF
--- a/lib/drivers/abstract/spellbook.js
+++ b/lib/drivers/abstract/spellbook.js
@@ -300,7 +300,7 @@ function formatSelectWithoutJoin(spell) {
   const values = [];
 
   // see https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html
-  const hintStr = this.formatOptimizeHint(spell);
+  const hintStr = this.formatOptimizerHints(spell);
 
   if (hintStr) {
     chunks.push(hintStr);
@@ -325,7 +325,7 @@ function formatSelectWithoutJoin(spell) {
   }
 
    // see https://dev.mysql.com/doc/refman/8.0/en/index-hints.html
-  const indexHintStr = this.formatIndexHint(spell);
+  const indexHintStr = this.formatIndexHints(spell);
   if (indexHintStr) {
     chunks.push(indexHintStr);
   }
@@ -492,7 +492,7 @@ function formatSelectWithJoin(spell) {
   const selects = formatSelectExpr(spell, values);
 
   // see https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html
-  const hintStr = this.formatOptimizeHint(spell);
+  const hintStr = this.formatOptimizerHints(spell);
 
   if (hintStr) {
     chunks.push(hintStr);
@@ -515,7 +515,7 @@ function formatSelectWithJoin(spell) {
   }
 
   // see https://dev.mysql.com/doc/refman/8.0/en/index-hints.html
-  const indexHintStr = this.formatIndexHint(spell);
+  const indexHintStr = this.formatIndexHints(spell);
   if (indexHintStr) {
     chunks.push(indexHintStr);
   }
@@ -576,7 +576,7 @@ function formatDelete(spell) {
   const chunks = ['DELETE'];
 
   // see https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html
-  const hintStr = this.formatOptimizeHint(spell);
+  const hintStr = this.formatOptimizerHints(spell);
   if (hintStr) {
     chunks.push(hintStr);
   }
@@ -639,7 +639,7 @@ function formatInsert(spell) {
   const chunks = ['INSERT'];
 
   // see https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html
-  const hintStr = this.formatOptimizeHint(spell);
+  const hintStr = this.formatOptimizerHints(spell);
   if (hintStr) {
     chunks.push(hintStr);
   }
@@ -691,9 +691,9 @@ function formatUpdate(spell) {
 
   whereConditions.reduce(collectLiteral, values);
   // see https://dev.mysql.com/doc/refman/8.0/en/optimizer-hints.html
-  const hintStr = this.formatOptimizeHint(spell);
+  const hintStr = this.formatOptimizerHints(spell);
   // see https://dev.mysql.com/doc/refman/8.0/en/index-hints.html
-  const indexHintStr = this.formatIndexHint(spell);
+  const indexHintStr = this.formatIndexHints(spell);
 
   if (hintStr) {
     chunks.push(hintStr);
@@ -770,17 +770,19 @@ module.exports = {
     }
   },
 
-  // override
-  formatHint() {
+  /**
+   * @abstract
+   * @returns {string} optimizer hints
+   */
+  formatOptimizerHints() {
     return '';
   },
 
-  // override
-  formatOptimizeHint() {
-    return '';
-  },
-  // override
-  formatIndexHint() {
+  /**
+   * @abstract
+   * @returns {string} index hints
+   */
+  formatIndexHints() {
     return '';
   },
 

--- a/lib/drivers/mysql/spellbook.js
+++ b/lib/drivers/mysql/spellbook.js
@@ -2,7 +2,7 @@
 
 const SqlString = require('sqlstring');
 
-const { IndexHint } = require('../../hint');
+const { Hint, IndexHint } = require('../../hint');
 
 const spellbook = require('../abstract/spellbook');
 
@@ -50,18 +50,22 @@ function formatMysqlUpsert(spell) {
 module.exports = {
   ...spellbook,
 
-  formatOptimizeHint(spell) {
-    if (!spell || !spell.optimizeHint.length) return '';
-    const hintStr = spell.optimizeHint.map(hint => hint.toSqlString()).join(' ');
-    return `/*+ ${hintStr} */`;
+  formatOptimizerHints(spell) {
+    const optimizerHints = spell.hints.filter(hint => hint instanceof Hint);
+    if (Array.isArray(optimizerHints) && optimizerHints.length > 0) {
+      const hints = optimizerHints.map(hint => hint.toSqlString()).join(' ');
+      return `/*+ ${hints} */`;
+    }
+    return '';
   },
 
-  formatIndexHint(spell) {
-    if (!spell || !spell.indexHint.length) return '';
-    // merge index hint
-    const hints = IndexHint.merge(spell.indexHint);
-    const hintStr = hints.map(hint => hint.toSqlString()).join(' ');
-    return `${hintStr}`;
+  formatIndexHints(spell) {
+    const indexHints = spell.hints.filter(hint => hint instanceof IndexHint);
+    if (Array.isArray(indexHints) && indexHints.length > 0) {
+      const hints = IndexHint.merge(indexHints);
+      return hints.map(hint => hint.toSqlString()).join(' ');
+    }
+    return '';
   },
 
   formatUpsert(spell) {

--- a/lib/hint.js
+++ b/lib/hint.js
@@ -1,81 +1,43 @@
 'use strict';
 
-const HINT_TYPE = {
-  TABLE_HINT: 'TABLE_HINT', // MSSQL only
-  INDEX_HINT: 'INDEX_HINT', // MYSQL only
-  OPTIMIZE_HINT: 'OPTIMIZE_HINT', // MySQL only
-}
+const { isDeepStrictEqual, format } = require('util');
+const { isPlainObject } = require('./utils');
 
 const INDEX_HINT_TYPE = {
-  USE: 'USE',
-  FORCE: 'FORCE',
-  IGNORE: 'IGNORE',
+  use: 'use',
+  force: 'force',
+  ignore: 'ignore',
 }
 
-const INDEX_HINT_USE_TYPE = {
-  JOIN: 'JOIN',
-  ORDER_BY: 'ORDER BY',
-  GROUP_BY: 'GROUP BY',
-}
-
-class LeoricHintError extends Error {
-  constructor(type, message) {
-    const errorMessage = message || `${type} is not a valid Hint type`;
-    super(errorMessage);
-    this.name = 'LeoricHintError';
-  }
-}
+const INDEX_HINT_SCOPE = {
+  join: 'join',
+  orderBy: 'order by',
+  groupBy: 'group by',
+};
 
 class Hint {
 
-  #value = '';
-  #type = HINT_TYPE.OPTIMIZE_HINT;
+  #text = '';
 
-  static build(obj) {
-    if (obj instanceof Hint) {
-      return obj;
-    }
-    if (typeof obj === 'string') {
-      return new Hint(obj);
-    }
-    const { type, indexHintType, useType, value } = obj;
-    if (indexHintType || type === HINT_TYPE.INDEX_HINT) {
-      return new IndexHint(value, indexHintType, useType);
-    }
-    if (Object.keys(INDEX_HINT_TYPE).includes(type)) {
-      return new IndexHint(value, type, useType);
-    }
-    return new Hint(value, type);
+  static build(hint) {
+    if (hint instanceof Hint || hint instanceof IndexHint) return hint;
+    if (isPlainObject(hint) && hint.index) return IndexHint.build(hint);
+    return new Hint(hint);
   }
 
-  constructor(value, type) {
-    if (type && !Object.keys(HINT_TYPE).includes(type)) {
-      throw new LeoricHintError(type);
+  constructor(text) {
+    this.text = text;
+  }
+
+  set text(value) {
+    if (typeof value !== 'string') {
+      throw new SyntaxError(`Unknown optimizer hint ${value}`);
     }
-    this.#value = value;
-    this.#type = type || HINT_TYPE.OPTIMIZE_HINT;
+    this.#text = value.replace(/^\s*\/\*\+|\*\/\s*$/g, '').trim();
   }
 
-  set value(v) {
-    if (v) {
-      this.#value = v.replace(/[\/\*\+]|[\*\/]/g, '');
-    }
-  }
-
-  get type() {
-    return this.#type;
-  }
-
-  set type(t) {
-    if (!t) return;
-    if (Object.keys(HINT_TYPE).includes(t.toUpperCase())) {
-      this.#type = t;
-    }
-    throw new LeoricHintError(t);
-  }
-
-  get value() {
-    return this.#value;
+  get text() {
+    return this.#text;
   }
 
   /**
@@ -85,88 +47,119 @@ class Hint {
    * @memberof Hint
    */
   isEqual(hint) {
-    if (!hint) return false;
-    return hint.type === this.type && this.value === hint.value;
+    return hint instanceof Hint && this.text === hint.text;
   }
 
   toSqlString() {
-    if (this.#value) {
-      return this.#value;
-    }
-    return '';
+    return this.#text;
   }
 }
 
-// MSSQL(Microsoft SQL Server) only, not support yet
-class TableHint extends Hint {
-  constructor(value) {
-    super(value, HINT_TYPE.TABLE_HINT)
-  }
-}
+// MySQL only
+class IndexHint {
 
-// MYSQL only
-class IndexHint extends Hint {
+  #type = INDEX_HINT_TYPE.use;
+  #scope = '';
+  #index = [];
 
-  #indexHintType = INDEX_HINT_TYPE.USE;
-  #useType = null;
   /**
-   *Creates an instance of IndexHint.
-   * @param {Array<string> | string} value
-   * @param {enum<INDEX_HINT_TYPE>?} indexHintType
-   * @param {enum<INDEX_HINT_USE_TYPE>?} useType
+   * build index hint
+   *
+   * @static
+   * @param {object | string} obj
+   * @param {string} indexHintType
+   * @returns {IndexHint}
+   * @example
+   * build('idx_title')
+   * build('idx_title', type: INDEX_HINT_TYPE.force, INDEX_HINT_SCOPE.groupBy)
+   * build({
+   *   index: 'idx_title',
+   *   type: INDEX_HINT_TYPE.ignore,
+   *   scope: INDEX_HINT_SCOPE.groupBy,
+   * })
+   */
+  static build(hint, type, scope) {
+    if (typeof hint === 'string' || Array.isArray(hint)) {
+      return new IndexHint(hint, type, scope);
+    }
+
+    if (isPlainObject(hint)) {
+      if (hint.index != null) {
+        return new IndexHint(hint.index, hint.type, hint.scope);
+      }
+
+      for (const key in INDEX_HINT_SCOPE) {
+        if (hint.hasOwnProperty(key)) {
+          const index = hint[key];
+          return new IndexHint(index, type, INDEX_HINT_SCOPE[key]);
+        }
+      }
+    }
+
+    throw new SyntaxError(format('Unknown index hint %s', hint));
+  }
+
+  /**
+   * Creates an instance of IndexHint.
+   * @param {Array<string> | string} index
+   * @param {enum<INDEX_HINT_TYPE>} type
+   * @param {enum<INDEX_HINT_SCOPE>?} scope
    * @memberof IndexHint
    */
-  constructor(value, indexHintType, useType){
-    super(value, HINT_TYPE.INDEX_HINT);
-    if (indexHintType && !Object.keys(INDEX_HINT_TYPE).includes(indexHintType)) {
-      throw new LeoricHintError(indexHintType);
-    }
-    if (useType && !Object.values(INDEX_HINT_USE_TYPE).includes(useType)) {
-      throw new LeoricHintError(useType);
-    }
-    this.#indexHintType = indexHintType || INDEX_HINT_TYPE.USE;
-    this.#useType = useType;
+  constructor(index, type = INDEX_HINT_TYPE.use, scope = ''){
+    this.index = index;
+    this.type = type;
+    this.scope = scope;
   }
 
-  set indexHintType(type) {
-    if (!type) return;
-    if (Object.keys(INDEX_HINT_TYPE).includes(type.toUpperCase())) {
-      this.#indexHintType = type;
+  set index(values) {
+    values = [].concat(values);
+
+    for (const value of values) {
+      if (typeof value !== 'string' || !value.trim()) {
+        throw new SyntaxError(format('Unknown index hint %s', value));
+      }
     }
-    throw new LeoricHintError(type);
+
+    this.#index = values;
   }
 
-  get indexHintType() {
-    return this.#indexHintType;
+  get index() {
+    return this.#index;
   }
 
-  get useType() {
-    return this.#useType;
-  }
-
-  set useType(type) {
-    if (!type) return;
-    if (Object.values(INDEX_HINT_USE_TYPE).includes(type.toUpperCase())) {
-      this.#useType = type;
+  set type(value) {
+    if (!Object.values(INDEX_HINT_TYPE).includes(value)) {
+      throw new SyntaxError(format('Unknown index hint type %s', value));
     }
-    throw new LeoricHintError(type);
+    this.#type = value;
+  }
+
+  get type() {
+    return this.#type;
+  }
+
+  set scope(value) {
+    if (value && !Object.values(INDEX_HINT_SCOPE).includes(value)) {
+      throw new SyntaxError(format('Unknown index hint scope %s', value));
+    }
+    this.#scope = value || '';
+  }
+
+  get scope() {
+    return this.#scope;
   }
 
   toSqlString() {
-    if (!this.value || !this.indexHintType) return '';
-    const chunks = [this.indexHintType, 'INDEX'];
-    if (this.#useType) {
-      chunks.push(`FOR ${this.useType}`);
+    const { type, scope, index } = this;
+    const chunks = [ type.toUpperCase(), 'INDEX' ];
+
+    if (scope) {
+      chunks.push(`FOR ${scope.toUpperCase()}`);
     }
-    if (typeof this.value === 'string') {
-      chunks.push(`(${this.value})`);
-      return chunks.join(' ');
-    }
-    if (Array.isArray(this.value) && this.value.some(item => typeof item === "string")) {
-      chunks.push(`(${this.value.join(',')})`);
-      return chunks.join(' ');
-    }
-    return '';
+
+    chunks.push(`(${index.join(',')})`);
+    return chunks.join(' ');
   }
 
   /**
@@ -176,18 +169,13 @@ class IndexHint extends Hint {
    * @memberof IndexHint
    */
   isEqual(hint) {
-    if (!hint) return false;
-    return hint.type === this.type && this.value === hint.value && this.indexHintType === hint.indexHintType && this.useType === hint.useType;
+    return hint instanceof IndexHint
+      && this.type === hint.type
+      && this.scope === hint.scope
+      && isDeepStrictEqual(this.index, hint.index);
   }
 
-  static copy(hint) {
-    return new IndexHint(hint.value, hint.indexHintType, hint.useType);
-  }
-
-  // static
   /**
-   *
-   *
    * @static
    * @param {IndexHint} hints
    * @returns {Array<IndexHint>}
@@ -195,56 +183,30 @@ class IndexHint extends Hint {
    */
   static merge(hints) {
     if (!hints || !hints.length) return hints;
+
     const grouped = {};
     for (const hint of hints) {
-      const key = `${hint.indexHintType}_${hint.useType || ''}`;
-      if (Object.keys(grouped).includes(key)) {
-        grouped[key].push(hint);
-      } else {
-        grouped[key] = [hint];
-      }
+      const key = `${hint.type}_${hint.scope}`;
+      grouped[key] = (grouped[key] || []).concat(hint.index);
     }
 
-    const groupArr = [];
+    const result = [];
     for (const key in grouped) {
-      let newIndexHint;
-      if (grouped[key].length === 1) {
-        const hint = grouped[key][0];
-        newIndexHint = IndexHint.copy(hint);
-      } else {
-        const sampleHint = grouped[key][0];
-        newIndexHint = new IndexHint(grouped[key].map(item => item.value), sampleHint.indexHintType, sampleHint.useType);
-      }
-      groupArr.push(newIndexHint);
+      const indices = grouped[key].reduce((result, index) => {
+        if (!result.includes(index)) result.push(index);
+        return result;
+      }, []);
+      const [type, scope] = key.split('_');
+      result.push(new IndexHint(indices, type, scope));
     }
 
-    return groupArr;
-  }
-
-  /**
-   * build with indexHintType
-   *
-   * @static
-   * @param {object | string} obj
-   * @param {string} indexHintType
-   * @returns {IndexHint}
-   * @memberof IndexHint
-   */
-  static buildWithType(obj, indexHintType) {
-    if (typeof obj === 'string') {
-      return new IndexHint(obj, indexHintType);
-    }
-    const { useType, value, useFor } = obj;
-    return new IndexHint(value, indexHintType, useType || useFor);
+    return result;
   }
 }
 
 module.exports = {
   Hint,
   IndexHint,
-  TableHint,
   INDEX_HINT_TYPE,
-  HINT_TYPE,
-  INDEX_HINT_USE_TYPE,
-  LeoricHintError,
+  INDEX_HINT_SCOPE,
 };

--- a/lib/spell.js
+++ b/lib/spell.js
@@ -8,7 +8,7 @@ const pluralize = require('pluralize');
 const SqlString = require('sqlstring');
 const { parseExprList, parseExpr, walkExpr } = require('./expr');
 const { isPlainObject } = require('./utils');
-const { HINT_TYPE, Hint, LeoricHintError, IndexHint, INDEX_HINT_TYPE } = require('./hint');
+const { IndexHint, INDEX_HINT_TYPE, Hint } = require('./hint');
 
 const OPERATOR_MAP = {
   $between: 'between',
@@ -448,22 +448,6 @@ function scopeDeletedAt(spell) {
 scopeDeletedAt.__paranoid = true;
 
 /**
- * unique spell hints
- *
- * @param {Spell} spell
- */
-function uniqueHints(spell) {
-  let hints = [];
-  // unique all hints
-  spell.hints.reduce(((arr, val) => {
-    if (!arr.find((i) => i.isEqual(val))) arr.push(val);
-    return arr;
-  }), hints);
-
-  spell.hints = hints;
-}
-
-/**
  * Spell is the query builder of Leoric which has several important charactors that made a powerful querying interface possible.
  *
  * - Deferred
@@ -536,7 +520,6 @@ class Spell {
       subqueryIndex: 0
     }, opts);
 
-
     const hints = [];
 
     if (opts.hints && opts.hints.length) {
@@ -547,10 +530,12 @@ class Spell {
       hints.push(Hint.build(opts.hint));
     }
 
-    this.hints = hints;
-
-    uniqueHints(this);
-
+    this.hints = hints.reduce((result, hint) => {
+      if (!result.some(entry => entry.isEqual(hint))) {
+        result.push(hint);
+      }
+      return result;
+    }, []);
   }
 
   static expr(text) {
@@ -603,14 +588,6 @@ class Spell {
       laters: [...this.laters],
       hints: [...this.hints],
     });
-  }
-
-  get indexHint() {
-    return this.hints.filter((hint) => hint.type === HINT_TYPE.INDEX_HINT);
-  }
-
-  get optimizeHint() {
-    return this.hints.filter((hint) => hint.type === HINT_TYPE.OPTIMIZE_HINT);
   }
 
   /**
@@ -983,39 +960,30 @@ class Spell {
   }
 
   /**
-   * add optimize hints to query
+   * add optimizer hints to query
    * @example
-   * .optimizeHints('SET_VAR(foreign_key_checks=OFF')
-   * .optimizeHints('SET_VAR(foreign_key_checks=OFF', 'MAX_EXECUTION_TIME(1000)')
-   * @param {string} hints
+   * .optimizeHints('SET_VAR(foreign_key_checks=OFF)')
+   * .optimizeHints('SET_VAR(foreign_key_checks=OFF)', 'MAX_EXECUTION_TIME(1000)')
+   * @param {...string} hints
    * @returns {Spell}
    * @memberof Spell
    */
-  $optimizeHints(...hints) {
-    if (hints.some((item) => typeof item !== 'string')) {
-      throw new LeoricHintError(typeof item);
-    }
+  $optimizerHints(...hints) {
     this.hints.push(...hints.map(hint => Hint.build(hint)));
-    uniqueHints(this);
     return this;
   }
 
   /**
-   * add USE INDEX to query
    * @example
    * .useIndex('idx_id')
    * .useIndex('idx_id', 'idx_title_id')
-   * .useIndex('idx_id', { value: ['idx_title', 'idx_org_id'], useFor: 'ORDER BY' }, { value: 'idx_type', useFor: 'GROUP BY' })
+   * .useIndex('idx_id', { orderBy: ['idx_title', 'idx_org_id'] }, { groupBy: 'idx_type' })
    * @param {string | object} hints
    * @returns {Spell}
    * @memberof Spell
    */
   $useIndex(...hints) {
-    if (hints.some((item) => typeof item !== 'string' && typeof item !== 'object')) {
-      throw new LeoricHintError(typeof item);
-    }
-    this.hints.push(...hints.map(hint => IndexHint.buildWithType(hint, INDEX_HINT_TYPE.USE)));
-    uniqueHints(this);
+    this.hints.push(...hints.map(hint => IndexHint.build(hint, INDEX_HINT_TYPE.use)));
     return this;
   }
 
@@ -1023,17 +991,13 @@ class Spell {
    * @example
    * .forceIndex('idx_id')
    * .forceIndex('idx_id', 'idx_title_id')
-   * .forceIndex('idx_id', { value: ['idx_title', 'idx_org_id'], useFor: 'ORDER BY' }, { value: 'idx_type', useFor: 'GROUP BY' })
+   * .forceIndex('idx_id', { orderBy: ['idx_title', 'idx_org_id'] }, { groupBy: 'idx_type' })
    * @param {string | object} hints
    * @returns {Spell}
    * @memberof Spell
    */
   $forceIndex(...hints) {
-    if (hints.some((item) => typeof item !== 'string' && typeof item !== 'object')) {
-      throw new LeoricHintError(typeof item);
-    }
-    this.hints.push(...hints.map(hint => IndexHint.buildWithType(hint, INDEX_HINT_TYPE.FORCE)));
-    uniqueHints(this);
+    this.hints.push(...hints.map(hint => IndexHint.build(hint, INDEX_HINT_TYPE.force)));
     return this;
   }
 
@@ -1041,17 +1005,13 @@ class Spell {
    * @example
    * .ignoreIndex('idx_id')
    * .ignoreIndex('idx_id', 'idx_title_id')
-   * .ignoreIndex('idx_id', { value: ['idx_title', 'idx_org_id'], useFor: 'ORDER BY' }, { value: 'idx_type', useFor: 'GROUP BY' })
+   * .ignoreIndex('idx_id', { orderBy: ['idx_title', 'idx_org_id'] }, { groupBy: 'idx_type' })
    * @param {string | object} hints
    * @returns {Spell}
    * @memberof Spell
    */
   $ignoreIndex(...hints) {
-    if (hints.some((item) => typeof item !== 'string' && typeof item !== 'object')) {
-      throw new LeoricHintError(typeof item);
-    }
-    this.hints.push(...hints.map(hint => IndexHint.buildWithType(hint, INDEX_HINT_TYPE.IGNORE)));
-    uniqueHints(this);
+    this.hints.push(...hints.map(hint => IndexHint.build(hint, INDEX_HINT_TYPE.ignore)));
     return this;
   }
 

--- a/test/start.sh
+++ b/test/start.sh
@@ -14,7 +14,7 @@ function run {
 function unit {
   # recursive glob nor available in bash 3
   # - https://unix.stackexchange.com/questions/49913/recursive-glob
-  for file in $(ls test/unit/{,drivers/,drivers/*/,adapters/,adapters/*/}*.test.js); do
+  for file in $(ls test/unit/{,drivers/,drivers/*/,adapters/}*.test.js); do
     run ${file};
   done
 }

--- a/test/unit/hint.test.js
+++ b/test/unit/hint.test.js
@@ -6,7 +6,47 @@ const path = require('path');
 const { connect } = require('../..');
 const Post = require('../models/post');
 
-const { IndexHint, Hint, INDEX_HINT_TYPE, INDEX_HINT_USE_TYPE, HINT_TYPE } = require('../../lib/hint');
+const { Hint, IndexHint, INDEX_HINT_TYPE, INDEX_HINT_SCOPE } = require('../../lib/hint');
+
+describe('Hint', () => {
+  it('text= should strip comment syntax', () => {
+    const hint = new Hint('/*+ SET_VAR(foreign_key_checks=OFF) */');
+    assert.equal(hint.text, 'SET_VAR(foreign_key_checks=OFF)');
+  });
+
+  it('isEqual() should compare with actual hint text', () => {
+    const hint = new Hint('SET_VAR(foreign_key_checks=OFF)');
+    const hint2 = new Hint('SET_VAR(foreign_key_checks=OFF)');
+    assert.notEqual(hint, hint2);
+    assert.ok(hint.isEqual(hint2));
+  });
+});
+
+describe('IndexHint', () => {
+  it('index= should convert value to string[]', () => {
+    const hint = new IndexHint('idx_name');
+    assert.deepEqual(hint.index, ['idx_name']);
+  });
+
+  it('type= should throw when value is not valid', () => {
+    const hint = new IndexHint('idx_name');
+    assert.doesNotThrow(() => {
+      hint.type = INDEX_HINT_TYPE.force;
+      assert.equal(hint.type, INDEX_HINT_TYPE.force);
+    });
+    assert.throws(() => {
+      hint.type = 'foo';
+    }, /unknown index hint type/i);
+  });
+
+  it('scope= should throw when value is not valid', () => {
+    const hint = new IndexHint('idx_name', INDEX_HINT_TYPE.ignore, INDEX_HINT_SCOPE.groupBy);
+    assert.equal(hint.scope, INDEX_HINT_SCOPE.groupBy);
+    assert.throws(() => {
+      hint.scope = 'bar';
+    }, /unknown index hint scope/i);
+  });
+});
 
 describe('MySQL', async () => {
   before(async function() {
@@ -18,36 +58,52 @@ describe('MySQL', async () => {
     });
   });
 
-  describe('optimize hint', () => {
-
+  describe('optimizer hint', () => {
     it('insert', () => {
       const date = new Date(2017, 11, 12);
       assert.equal(
-        Post.create({ title: 'New Post', createdAt: date, updatedAt: date }, { hint: new Hint('SET_VAR(foreign_key_checks=OFF)') }).toString(),
+        Post.create({ title: 'New Post', createdAt: date, updatedAt: date }, {
+          hint: new Hint('SET_VAR(foreign_key_checks=OFF)')
+        }).toString(),
         "INSERT /*+ SET_VAR(foreign_key_checks=OFF) */ INTO `articles` (`gmt_create`, `gmt_modified`, `title`) VALUES ('2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000', 'New Post')"
       );
       assert.equal(
-        Post.create({ title: 'New Post', createdAt: date, updatedAt: date }).optimizeHints('SET_VAR(foreign_key_checks=OFF)').toString(),
+        Post.create({ title: 'New Post', createdAt: date, updatedAt: date })
+          .optimizerHints('SET_VAR(foreign_key_checks=OFF)')
+          .toString(),
         "INSERT /*+ SET_VAR(foreign_key_checks=OFF) */ INTO `articles` (`gmt_create`, `gmt_modified`, `title`) VALUES ('2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000', 'New Post')"
       );
       // array
       assert.equal(
-        Post.create({ title: 'New Post', createdAt: date, updatedAt: date }, { hints: [ new Hint('SET_VAR(foreign_key_checks=OFF)'), new Hint('SET_VAR(sort_buffer_size = 16M)') ] }).toString(),
+        Post.create({ title: 'New Post', createdAt: date, updatedAt: date }, {
+          hints: [
+            new Hint('SET_VAR(foreign_key_checks=OFF)'),
+            new Hint('SET_VAR(sort_buffer_size = 16M)'),
+          ],
+        }).toString(),
         "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) */ INTO `articles` (`gmt_create`, `gmt_modified`, `title`) VALUES ('2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000', 'New Post')"
       );
 
       assert.equal(
-        Post.create({ title: 'New Post', createdAt: date, updatedAt: date }).optimizeHints('SET_VAR(foreign_key_checks=OFF)', 'SET_VAR(sort_buffer_size = 16M)').toString(),
+        Post.create({ title: 'New Post', createdAt: date, updatedAt: date })
+          .optimizerHints('SET_VAR(foreign_key_checks=OFF)', 'SET_VAR(sort_buffer_size = 16M)')
+          .toString(),
         "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) */ INTO `articles` (`gmt_create`, `gmt_modified`, `title`) VALUES ('2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000', 'New Post')"
       );
 
       assert.equal(
-        Post.create({ title: 'New Post', createdAt: date, updatedAt: date }).optimizeHints('SET_VAR(foreign_key_checks=OFF)').optimizeHints('SET_VAR(sort_buffer_size = 16M)').toString(),
+        Post.create({ title: 'New Post', createdAt: date, updatedAt: date }).optimizerHints('SET_VAR(foreign_key_checks=OFF)').optimizerHints('SET_VAR(sort_buffer_size = 16M)').toString(),
         "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) */ INTO `articles` (`gmt_create`, `gmt_modified`, `title`) VALUES ('2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000', 'New Post')"
       );
 
       assert.equal(
-        Post.create({ title: 'New Post', createdAt: date, updatedAt: date }, { hints: [ new Hint('SET_VAR(foreign_key_checks=OFF)'), new Hint('SET_VAR(sort_buffer_size = 16M)'), { value: 'BKA(users)' } ] }).toString(),
+        Post.create({ title: 'New Post', createdAt: date, updatedAt: date }, {
+          hints: [
+            new Hint('SET_VAR(foreign_key_checks=OFF)'),
+            new Hint('SET_VAR(sort_buffer_size = 16M)'),
+            new Hint('BKA(users)'),
+          ],
+        }).toString(),
         "INSERT /*+ SET_VAR(foreign_key_checks=OFF) SET_VAR(sort_buffer_size = 16M) BKA(users) */ INTO `articles` (`gmt_create`, `gmt_modified`, `title`) VALUES ('2017-12-12 00:00:00.000', '2017-12-12 00:00:00.000', 'New Post')"
       );
 
@@ -67,7 +123,7 @@ describe('MySQL', async () => {
       );
 
       assert.equal(
-        Post.find({ title: { $like: '%Post%' } }).optimizeHints('SET_VAR(foreign_key_checks=OFF)').toString(),
+        Post.find({ title: { $like: '%Post%' } }).optimizerHints('SET_VAR(foreign_key_checks=OFF)').toString(),
         "SELECT /*+ SET_VAR(foreign_key_checks=OFF) */ * FROM `articles` WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL"
       );
 
@@ -77,7 +133,7 @@ describe('MySQL', async () => {
       );
 
       assert.equal(
-        Post.find({ title: { $like: '%Post%' } }).optimizeHints('SET_VAR(foreign_key_checks=OFF)', 'MAX_EXECUTION_TIME(1000)').toString(),
+        Post.find({ title: { $like: '%Post%' } }).optimizerHints('SET_VAR(foreign_key_checks=OFF)', 'MAX_EXECUTION_TIME(1000)').toString(),
         "SELECT /*+ SET_VAR(foreign_key_checks=OFF) MAX_EXECUTION_TIME(1000) */ * FROM `articles` WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL"
       );
     });
@@ -107,7 +163,7 @@ describe('MySQL', async () => {
   describe('index hint', () => {
     it('find', () => {
       assert.equal(
-        Post.find({ title: { $like: '%Post%' } }, { hint: new IndexHint('idx_title', INDEX_HINT_TYPE.USE) }).toString(),
+        Post.find({ title: { $like: '%Post%' } }).useIndex('idx_title').toString(),
         "SELECT * FROM `articles` USE INDEX (idx_title) WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL"
       );
 
@@ -119,7 +175,7 @@ describe('MySQL', async () => {
 
       // use for
       assert.equal(
-        Post.find({ title: { $like: '%Post%' } }, { order: 'id', hints: [ new IndexHint('idx_id', INDEX_HINT_TYPE.USE, INDEX_HINT_USE_TYPE.ORDER_BY), new IndexHint('idx_title'), new IndexHint('idx_title') ] }).toString(),
+        Post.find({ title: { $like: '%Post%' } }, { order: 'id', hints: [ new IndexHint('idx_id', INDEX_HINT_TYPE.use, INDEX_HINT_SCOPE.orderBy), new IndexHint('idx_title'), new IndexHint('idx_title') ] }).toString(),
         "SELECT * FROM `articles` USE INDEX FOR ORDER BY (idx_id) USE INDEX (idx_title) WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL ORDER BY `id`"
       );
 
@@ -127,14 +183,14 @@ describe('MySQL', async () => {
         Post.find({ title: { $like: '%Post%' } }, {
           order: 'id asc',
           hints: [
-            new IndexHint('idx_id', INDEX_HINT_TYPE.FORCE),
-            new IndexHint('idx_title', INDEX_HINT_TYPE.FORCE),
-            new IndexHint('idx_title', INDEX_HINT_TYPE.FORCE),
-            new IndexHint('idx_title', INDEX_HINT_TYPE.FORCE, INDEX_HINT_USE_TYPE.ORDER_BY), // USE INDEX FOR ** ()
-            new IndexHint('idx_hle', INDEX_HINT_TYPE.IGNORE),
-            new IndexHint('idx_hle1', INDEX_HINT_TYPE.IGNORE),
-            new IndexHint('idx_hle', INDEX_HINT_TYPE.IGNORE),
-            new IndexHint('idx_hle2', INDEX_HINT_TYPE.USE),
+            new IndexHint('idx_id', INDEX_HINT_TYPE.force),
+            new IndexHint('idx_title', INDEX_HINT_TYPE.force),
+            new IndexHint('idx_title', INDEX_HINT_TYPE.force),
+            new IndexHint('idx_title', INDEX_HINT_TYPE.force, INDEX_HINT_SCOPE.orderBy), // USE INDEX FOR ** ()
+            new IndexHint('idx_hle', INDEX_HINT_TYPE.ignore),
+            new IndexHint('idx_hle1', INDEX_HINT_TYPE.ignore),
+            new IndexHint('idx_hle', INDEX_HINT_TYPE.ignore),
+            new IndexHint('idx_hle2', INDEX_HINT_TYPE.use),
           ]
         }).toString(),
         "SELECT * FROM `articles` FORCE INDEX (idx_id,idx_title) FORCE INDEX FOR ORDER BY (idx_title) IGNORE INDEX (idx_hle,idx_hle1) USE INDEX (idx_hle2) WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL ORDER BY `id`"
@@ -144,35 +200,36 @@ describe('MySQL', async () => {
         Post.find({ title: { $like: '%Post%' } }, { order: 'id asc' })
           .forceIndex('idx_id', 'idx_title')
           .forceIndex('idx_title')
-          .forceIndex({ value: 'idx_title', useFor: 'ORDER BY' })
+          .forceIndex({ orderBy: 'idx_title' })
           .ignoreIndex('idx_hle', 'idx_hle1')
           .ignoreIndex('idx_hle')
           .useIndex('idx_hle2')
           .toString(),
-          "SELECT * FROM `articles` FORCE INDEX (idx_id,idx_title) FORCE INDEX FOR ORDER BY (idx_title) IGNORE INDEX (idx_hle,idx_hle1) USE INDEX (idx_hle2) WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL ORDER BY `id`"
+        "SELECT * FROM `articles` FORCE INDEX (idx_id,idx_title) FORCE INDEX FOR ORDER BY (idx_title) IGNORE INDEX (idx_hle,idx_hle1) USE INDEX (idx_hle2) WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL ORDER BY `id`"
       );
+
       // mixing
       assert.equal(
         Post.find({ title: { $like: '%Post%' } }, {
           order: 'id asc',
           hints: [
-            new IndexHint('idx_id', INDEX_HINT_TYPE.FORCE),
-            new IndexHint('idx_title', INDEX_HINT_TYPE.FORCE),
-            new IndexHint('idx_title', INDEX_HINT_TYPE.FORCE),
-            new IndexHint('idx_title', INDEX_HINT_TYPE.FORCE, INDEX_HINT_USE_TYPE.ORDER_BY), // USE INDEX FOR ** ()
-            new IndexHint('idx_hle', INDEX_HINT_TYPE.IGNORE),
-            new IndexHint('idx_hle1', INDEX_HINT_TYPE.IGNORE),
-            new IndexHint('idx_hle', INDEX_HINT_TYPE.IGNORE),
-            new IndexHint('idx_hle2', INDEX_HINT_TYPE.USE),
+            new IndexHint('idx_id', INDEX_HINT_TYPE.force),
+            new IndexHint('idx_title', INDEX_HINT_TYPE.force),
+            new IndexHint('idx_title', INDEX_HINT_TYPE.force),
+            new IndexHint('idx_title', INDEX_HINT_TYPE.force, INDEX_HINT_SCOPE.orderBy), // FORCE INDEX FOR ORDER BY ()
+            new IndexHint('idx_hle', INDEX_HINT_TYPE.ignore),
+            new IndexHint('idx_hle1', INDEX_HINT_TYPE.ignore),
+            new IndexHint('idx_hle', INDEX_HINT_TYPE.ignore),
+            new IndexHint('idx_hle2', INDEX_HINT_TYPE.use),
           ]
         })
-        .forceIndex('idx_id', 'idx_title')
-        .forceIndex('idx_title')
-        .forceIndex({ value: 'idx_title', useFor: 'ORDER BY' })
-        .ignoreIndex('idx_hle', 'idx_hle1')
-        .ignoreIndex('idx_hle')
-        .useIndex('idx_hle2')
-        .toString(),
+          .forceIndex('idx_id', 'idx_title')
+          .forceIndex('idx_title')
+          .forceIndex({ orderBy: 'idx_title' })
+          .ignoreIndex('idx_hle', 'idx_hle1')
+          .ignoreIndex('idx_hle')
+          .useIndex('idx_hle2')
+          .toString(),
         "SELECT * FROM `articles` FORCE INDEX (idx_id,idx_title) FORCE INDEX FOR ORDER BY (idx_title) IGNORE INDEX (idx_hle,idx_hle1) USE INDEX (idx_hle2) WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL ORDER BY `id`"
       );
     });
@@ -194,37 +251,37 @@ describe('MySQL', async () => {
       );
 
       assert.equal(
-        Post.update({
-          title: { $like: '%Post%' }
-        },
-        { title: 'hello', updatedAt: date },
-        { hints: [ new IndexHint('idx_id'), { value: 'idx_title', type: HINT_TYPE.INDEX_HINT }, new IndexHint('idx_title') ] }).toString(),
-        "UPDATE `articles` USE INDEX (idx_id,idx_title) SET `title` = 'hello', `gmt_modified` = '2017-12-12 00:00:00.000' WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL"
-      );
-
-      assert.equal(
-        Post.update({
-          title: { $like: '%Post%' }
-        },
-        { title: 'hello', updatedAt: date },
-        { hints: [ new IndexHint('idx_id'), { value: 'idx_title', type: INDEX_HINT_TYPE.USE }, new IndexHint('idx_title') ] }).toString(),
-        "UPDATE `articles` USE INDEX (idx_id,idx_title) SET `title` = 'hello', `gmt_modified` = '2017-12-12 00:00:00.000' WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL"
-      );
-
-      assert.equal(
-        Post.update({ title: { $like: '%Post%' } }, { title: 'hello', updatedAt: date },{
+        Post.update({ title: { $like: '%Post%' } }, { title: 'hello', updatedAt: date }, {
           hints: [
-            new IndexHint('idx_id', INDEX_HINT_TYPE.FORCE),
-            new IndexHint('idx_title', INDEX_HINT_TYPE.FORCE), //
-            new IndexHint('idx_title', INDEX_HINT_TYPE.FORCE), // unique
-            {
-              type: INDEX_HINT_TYPE.FORCE,
-              value: 'idx_title',
-            },
-            new IndexHint('idx_hle', INDEX_HINT_TYPE.IGNORE),
-            new IndexHint('idx_hle1', INDEX_HINT_TYPE.IGNORE),
-            new IndexHint('idx_hle', INDEX_HINT_TYPE.IGNORE),
-            new IndexHint('idx_hle2', INDEX_HINT_TYPE.USE),
+            new IndexHint('idx_id'),
+            { index: 'idx_title' },
+            new IndexHint('idx_title'),
+          ],
+        }).toString(),
+        "UPDATE `articles` USE INDEX (idx_id,idx_title) SET `title` = 'hello', `gmt_modified` = '2017-12-12 00:00:00.000' WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL"
+      );
+
+      assert.equal(
+        Post.update({ title: { $like: '%Post%' } }, { title: 'hello', updatedAt: date }, {
+          hints: [
+            new IndexHint('idx_id'),
+            { index: 'idx_title', type: INDEX_HINT_TYPE.use },
+            new IndexHint('idx_title')
+          ],
+        }).toString(),
+        "UPDATE `articles` USE INDEX (idx_id,idx_title) SET `title` = 'hello', `gmt_modified` = '2017-12-12 00:00:00.000' WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL"
+      );
+
+      assert.equal(
+        Post.update({ title: { $like: '%Post%' } }, { title: 'hello', updatedAt: date }, {
+          hints: [
+            new IndexHint('idx_id', INDEX_HINT_TYPE.force),
+            new IndexHint('idx_title', INDEX_HINT_TYPE.force),
+            new IndexHint('idx_title', INDEX_HINT_TYPE.force), // ignore duplicated
+            new IndexHint('idx_hle', INDEX_HINT_TYPE.ignore),
+            new IndexHint('idx_hle1', INDEX_HINT_TYPE.ignore),
+            new IndexHint('idx_hle', INDEX_HINT_TYPE.ignore),
+            new IndexHint('idx_hle2', INDEX_HINT_TYPE.use),
           ]
         }).toString(),
         "UPDATE `articles` FORCE INDEX (idx_id,idx_title) IGNORE INDEX (idx_hle,idx_hle1) USE INDEX (idx_hle2) SET `title` = 'hello', `gmt_modified` = '2017-12-12 00:00:00.000' WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL"
@@ -246,15 +303,15 @@ describe('MySQL', async () => {
     const date = new Date(2017, 11, 12);
 
     assert.equal(
-      Post.update({title: { $like: '%Post%' } }, { title: 'hello', updatedAt: date },{
+      Post.update({title: { $like: '%Post%' } }, { title: 'hello', updatedAt: date }, {
         hints: [
-          new IndexHint('idx_id', INDEX_HINT_TYPE.FORCE),
-          new IndexHint('idx_title', INDEX_HINT_TYPE.FORCE),
-          new IndexHint('idx_title', INDEX_HINT_TYPE.FORCE),
-          new IndexHint('idx_hle', INDEX_HINT_TYPE.IGNORE),
-          new IndexHint('idx_hle1', INDEX_HINT_TYPE.IGNORE),
-          new IndexHint('idx_hle', INDEX_HINT_TYPE.IGNORE),
-          new IndexHint('idx_hle2', INDEX_HINT_TYPE.USE),
+          new IndexHint('idx_id', INDEX_HINT_TYPE.force),
+          new IndexHint('idx_title', INDEX_HINT_TYPE.force),
+          new IndexHint('idx_title', INDEX_HINT_TYPE.force),
+          new IndexHint('idx_hle', INDEX_HINT_TYPE.ignore),
+          new IndexHint('idx_hle1', INDEX_HINT_TYPE.ignore),
+          new IndexHint('idx_hle', INDEX_HINT_TYPE.ignore),
+          new IndexHint('idx_hle2', INDEX_HINT_TYPE.use),
           new Hint('SET_VAR(foreign_key_checks=OFF)'),
           new Hint('MAX_EXECUTION_TIME(1000)')
         ]
@@ -264,11 +321,11 @@ describe('MySQL', async () => {
 
     assert.equal(
       Post.update({title: { $like: '%Post%' } }, { title: 'hello', updatedAt: date })
-      .optimizeHints('SET_VAR(foreign_key_checks=OFF)', 'MAX_EXECUTION_TIME(1000)')
-      .forceIndex('idx_id', 'idx_title')
-      .ignoreIndex('idx_hle', 'idx_hle1')
-      .useIndex('idx_hle2')
-      .toString(),
+        .optimizerHints('SET_VAR(foreign_key_checks=OFF)', 'MAX_EXECUTION_TIME(1000)')
+        .forceIndex('idx_id', 'idx_title')
+        .ignoreIndex('idx_hle', 'idx_hle1')
+        .useIndex('idx_hle2')
+        .toString(),
       "UPDATE /*+ SET_VAR(foreign_key_checks=OFF) MAX_EXECUTION_TIME(1000) */ `articles` FORCE INDEX (idx_id,idx_title) IGNORE INDEX (idx_hle,idx_hle1) USE INDEX (idx_hle2) SET `title` = 'hello', `gmt_modified` = '2017-12-12 00:00:00.000' WHERE `title` LIKE '%Post%' AND `gmt_deleted` IS NULL"
     );
   });

--- a/test/unit/spell.test.js
+++ b/test/unit/spell.test.js
@@ -644,6 +644,5 @@ describe('=> raw sql', () => {
         Bone.driver = null;
       });
     });
-
   });
 });


### PR DESCRIPTION
change index hint methods to `useIndex({ [scope]: ...indices })` such as `useIndex({ orderBy: 'idx_foo' })`. 

It looks like MySQL will start deprecating index hint in their next major version:

> As of MySQL 8.0.20, the server supports the index-level optimizer hints JOIN_INDEX, GROUP_INDEX, ORDER_INDEX, and INDEX, which are equivalent to and intended to supersede FORCE INDEX index hints ...

Hence I think we should keep the implementation here as simple as possible. 

- https://dev.mysql.com/doc/refman/8.0/en/index-hints.html